### PR TITLE
Add support for laravel octane

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,19 @@ name.
 - `amqp.connections.*.consumer` holds the default properties of consumer when consuming.
 - `amqp.connections.*.qos` holds the default properties of QoS when consuming.
 
+### Octane support
+
+From >=2.1 this package supports laravel octane by default, but you have to configure octane to `warm` the connection, by adding 'amqp' to the warm array in octane configurations.
+
+```php
+  // config\octane.php
+  // ... 
+   'warm' => [
+        // ... 
+        'amqp', // <-- this line
+    ],
+```
+
 ## Usage
 
 The followings work the same.

--- a/readme.md
+++ b/readme.md
@@ -86,15 +86,17 @@ name.
 
 ### Octane support
 
-From >=2.1 this package supports laravel octane by default, but you have to configure octane to `warm` the connection, by adding 'amqp' to the warm array in octane configurations.
+This package supports laravel octane by
+default. [To keep the AMQP connection alive](https://www.cloudamqp.com/blog/part4-rabbitmq-13-common-errors.html),
+you have to configure octane to `warm` the connection, by adding **'amqp'** to the warm array in octane configurations.
 
 ```php
-  // config\octane.php
-  // ... 
-   'warm' => [
-        // ... 
-        'amqp', // <-- this line
-    ],
+// config/octane.php
+// ... 
+'warm' => [
+    // ... 
+    'amqp', // <-- this line
+],
 ```
 
 ## Usage
@@ -287,6 +289,7 @@ class MyTest extends TestCase
         - If a message exactly matches the `$message`.
         - If a message exactly matches the `get_class($message)`.
         - If a message is an implementation of `$message`.
+
 ### Note
 
 Using `Anik\Laravel\Amqp\Facades\Amqp::consume()` after `Anik\Laravel\Amqp\Facades\Amqp::fake()` will throw exception.

--- a/src/Amqp.php
+++ b/src/Amqp.php
@@ -22,8 +22,6 @@ class Amqp implements AmqpPubSub
 
     private Producer $producer;
 
-    private Consumer $consumer;
-
     public function __construct(AbstractConnection $connection, array $config = [])
     {
         $this->connection = $connection;
@@ -32,12 +30,12 @@ class Amqp implements AmqpPubSub
 
     public function getProducer(): Producer
     {
-        return $this->producer ?? $this->producer = app()->make(Producer::class, ['connection' => $this->connection]);
+        return $this->producer ??= app()->make(Producer::class, ['connection' => $this->connection]);
     }
 
     public function getConsumer(array $options = []): Consumer
     {
-        return $this->consumer ?? $this->consumer = app()->make(
+        return app()->make(
             Consumer::class,
             ['connection' => $this->connection, 'channel' => null, 'options' => $options]
         );

--- a/src/Amqp.php
+++ b/src/Amqp.php
@@ -20,6 +20,10 @@ class Amqp implements AmqpPubSub
 
     private $config;
 
+    private Producer $producer;
+
+    private Consumer $consumer;
+
     public function __construct(AbstractConnection $connection, array $config = [])
     {
         $this->connection = $connection;
@@ -28,12 +32,12 @@ class Amqp implements AmqpPubSub
 
     public function getProducer(): Producer
     {
-        return app()->make(Producer::class, ['connection' => $this->connection]);
+        return $this->producer ?? $this->producer = app()->make(Producer::class, ['connection' => $this->connection]);
     }
 
     public function getConsumer(array $options = []): Consumer
     {
-        return app()->make(
+        return $this->consumer ?? $this->consumer = app()->make(
             Consumer::class,
             ['connection' => $this->connection, 'channel' => null, 'options' => $options]
         );

--- a/tests/AmqpTest.php
+++ b/tests/AmqpTest.php
@@ -347,7 +347,7 @@ class AmqpTest extends TestCase
     /**
      * @dataProvider publishMessageTestDataProvider
      *
-     * @param array $data
+     * @param  array  $data
      */
     public function testPublishFormatsMessagesToProducible(array $data)
     {
@@ -432,7 +432,7 @@ class AmqpTest extends TestCase
     /**
      * @dataProvider publishOptionsDataProvider
      *
-     * @param array $data
+     * @param  array  $data
      */
     public function testPublishPassesPublishOptionsIfAvailable(array $data)
     {
@@ -471,7 +471,7 @@ class AmqpTest extends TestCase
     /**
      * @dataProvider exchangeTestDataProvider
      *
-     * @param array $data
+     * @param  array  $data
      */
     public function testPublishMessageProcessesExchange(array $data)
     {
@@ -563,7 +563,7 @@ class AmqpTest extends TestCase
     /**
      * @dataProvider exchangeTestDataProvider
      *
-     * @param array $data
+     * @param  array  $data
      */
     public function testConsumerProcessesExchange(array $data)
     {
@@ -611,7 +611,7 @@ class AmqpTest extends TestCase
     /**
      * @dataProvider queueTestDataProvider
      *
-     * @param array $data
+     * @param  array  $data
      */
     public function testConsumerProcessesQueue(array $data)
     {
@@ -659,7 +659,7 @@ class AmqpTest extends TestCase
     /**
      * @dataProvider qosTestDataProvider
      *
-     * @param array $data
+     * @param  array  $data
      */
     public function testConsumerProcessesQos(array $data)
     {
@@ -714,7 +714,7 @@ class AmqpTest extends TestCase
     /**
      * @dataProvider queueBindTestDataProvider
      *
-     * @param array $data
+     * @param  array  $data
      */
     public function testConsumerProcessesQueueBind(array $data)
     {
@@ -762,7 +762,7 @@ class AmqpTest extends TestCase
     /**
      * @dataProvider consumerConfigTestDataProvider
      *
-     * @param array $data
+     * @param  array  $data
      */
     public function testConsumerProcessesConsumerConfig(array $data)
     {


### PR DESCRIPTION
This pull request is related to https://github.com/ssi-anik/amqp/issues/31, as this simple change will fix the issue while using laravel octane, 

This change will make laravel only resolve the connection once after the application boots (warm), the user of the package should add the connection to warm parameter in Octane configuration file. ( this been added to readme )

Making only one connection to rabbitmq for each Worker of laravel octane will boost the performance.

Best regards.